### PR TITLE
Feature/implement-search-for-catalogs/TT-117

### DIFF
--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsActivity.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsActivity.kt
@@ -552,6 +552,9 @@ class AllCatalogsActivity : AppCompatActivity() {
             }
         }
     }
-    fun onDeleteSearchIconClick(view: View) {}
+    fun onDeleteSearchIconClick(view: View) {
+        fetchCatalogs()
+        removeSearch.visibility=View.GONE
+    }
 
 }

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsActivity.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsActivity.kt
@@ -4,8 +4,10 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import android.widget.EditText
 import android.widget.ImageView
 import android.widget.ProgressBar
+import android.widget.Spinner
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -32,6 +34,7 @@ class AllCatalogsActivity : AppCompatActivity() {
     private lateinit var catalogAdapter: CatalogAdapter
 
     private lateinit var progressBar: ProgressBar
+    private lateinit var removeSearch: ImageView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -57,6 +60,7 @@ class AllCatalogsActivity : AppCompatActivity() {
         bottomNavigationView.visibility = View.VISIBLE
 
         progressBar = findViewById(R.id.loadingProgressBar)
+        removeSearch = findViewById(R.id.img_delete_search_icon)
 
         fetchCatalogs()
 
@@ -139,7 +143,53 @@ class AllCatalogsActivity : AppCompatActivity() {
         dialog.show()
     }
 
-    fun onSearchTransactionIconClick(view: View) {}
+    fun onSearchTransactionIconClick(view: View) {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_search_catalogs, null)
+
+        val etName = dialogView.findViewById<EditText>(R.id.etName)
+        val etArticle = dialogView.findViewById<EditText>(R.id.etArticle)
+        val etService = dialogView.findViewById<EditText>(R.id.etService)
+        val etUser = dialogView.findViewById<EditText>(R.id.etUser)
+        val progressBar = dialogView.findViewById<ProgressBar>(R.id.progressBarDialog)
+
+        //name article service user
+        // Initialization values of elements
+        etName.setText("")
+        etArticle.setText("")
+        etService.setText("")
+        etUser.setText("")
+
+        val builder = AlertDialog.Builder(this)
+            .setTitle("Search catalogs")
+            .setView(dialogView)
+            .setPositiveButton("Search") { dialog, _ ->
+
+                // Implement the search logic here
+                val name = etName.text.toString()
+                val article = etArticle.text.toString()
+                val service = etService.text.toString()
+                val user= etUser.text.toString()
+
+                // Pass the dialog view to the function
+                performSearchAndUpdateRecyclerView(
+                    name,
+                    article,
+                    service,
+                    user
+                )
+                removeSearch.visibility = View.VISIBLE
+                dialog.dismiss()
+            }
+            .setNegativeButton("Cancel") { dialog, _ ->
+                dialog.dismiss()
+            }
+
+       }
+
+    private fun performSearchAndUpdateRecyclerView(name: String, article: String, selectedMerchant: Any, progressBarMerchant: Any) {
+
+    }
+
     fun onDeleteSearchIconClick(view: View) {}
 
 }

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsActivity.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsActivity.kt
@@ -139,4 +139,7 @@ class AllCatalogsActivity : AppCompatActivity() {
         dialog.show()
     }
 
+    fun onSearchTransactionIconClick(view: View) {}
+    fun onDeleteSearchIconClick(view: View) {}
+
 }

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsActivity.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsActivity.kt
@@ -43,10 +43,6 @@ class AllCatalogsActivity : AppCompatActivity() {
     private lateinit var progressBar: ProgressBar
     private lateinit var removeSearch: ImageView
 
-    private var merchantId: String = ""
-    private var serviceId: String = ""
-    private var articleId: String = ""
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -160,16 +156,18 @@ class AllCatalogsActivity : AppCompatActivity() {
 
         val etName = dialogView.findViewById<EditText>(R.id.etName)
         val spinnerArticles = dialogView.findViewById<Spinner>(R.id.etArticle)
+        val progressBarDialog1 = dialogView.findViewById<ProgressBar>(R.id.progressBarDialog1)
         val spinnerServices = dialogView.findViewById<Spinner>(R.id.etService)
+        val progressBarDialog2 = dialogView.findViewById<ProgressBar>(R.id.progressBarDialog2)
         val spinnerUsers = dialogView.findViewById<Spinner>(R.id.etUser)
-        val progressBarDialog = dialogView.findViewById<ProgressBar>(R.id.progressBarDialog)
+        val progressBarDialog3 = dialogView.findViewById<ProgressBar>(R.id.progressBarDialog3)
 
         // Initialization values of elements
         etName.setText("")
 
-        fetchMerchantsForDialog(spinnerUsers, progressBarDialog)
-        fetchArticlesForDialog(spinnerArticles, progressBarDialog)
-        fetchServicesForSpinner(spinnerServices, progressBarDialog)
+        fetchArticlesForDialog(spinnerArticles, progressBarDialog1)
+        fetchServicesForSpinner(spinnerServices, progressBarDialog2)
+        fetchMerchantsForDialog(spinnerUsers, progressBarDialog3)
 
         val builder = AlertDialog.Builder(this)
             .setTitle("Search catalogs")
@@ -193,7 +191,7 @@ class AllCatalogsActivity : AppCompatActivity() {
                     articleSpinner,
                     serviceSpinner,
                     userSpinner,
-                    progressBarDialog
+                    progressBarDialog3
                 )
                 removeSearch.visibility = View.VISIBLE
                 dialog.dismiss()
@@ -483,6 +481,10 @@ class AllCatalogsActivity : AppCompatActivity() {
         progressBarDialog.visibility = View.VISIBLE
         progressBar.visibility = View.VISIBLE
 
+        var merchantId: String = ""
+        var serviceId: String = ""
+        var articleId: String = ""
+
         getUserIdFromName(userName) { fetchedMerchant ->
             if (userName == "Merchants") {
                 merchantId = ""
@@ -513,9 +515,9 @@ class AllCatalogsActivity : AppCompatActivity() {
 
                     val searchParams = mutableMapOf<String, String>().apply {
                         if (name.isNotEmpty()) put("name", name)
-                        if (merchantId.isNotEmpty()) put("merchantId", merchantId)
-                        if (serviceId.isNotEmpty()) put("serviceId", serviceId)
-                        if (articleId.isNotEmpty()) put("articleId", articleId)
+                        if (merchantId.isNotEmpty()) put("user", merchantId)
+                        if (serviceId.isNotEmpty()) put("service", serviceId)
+                        if (articleId.isNotEmpty()) put("article", articleId)
                     }
                     Log.d( "Name: ", name)
                     Log.d( "merchantId: ", merchantId)

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsMerchantActivity.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsMerchantActivity.kt
@@ -4,8 +4,11 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import android.widget.ArrayAdapter
+import android.widget.EditText
 import android.widget.ImageView
 import android.widget.ProgressBar
+import android.widget.Spinner
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -21,6 +24,9 @@ import hr.foi.techtitans.ttpay.navigationBar.activity_navigationBar.MerchantHome
 import hr.foi.techtitans.ttpay.network.RetrofitClient
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import hr.foi.techtitans.ttpay.core.LoggedInUser
+import hr.foi.techtitans.ttpay.products.model_products.Article
+import hr.foi.techtitans.ttpay.products.model_products.Service
+import hr.foi.techtitans.ttpay.products.network_products.ServiceProducts
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -37,6 +43,8 @@ class AllCatalogsMerchantActivity : AppCompatActivity() {
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: MerchantCatalogAdapter
 
+    private lateinit var removeSearch: ImageView
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_all_catalogs_merchant)
@@ -52,6 +60,8 @@ class AllCatalogsMerchantActivity : AppCompatActivity() {
 
         recyclerView = findViewById(R.id.recyclerView_all_catalogs_merchant)
         progressBar = findViewById(R.id.loadingProgressBar)
+        removeSearch = findViewById(R.id.img_delete_search_icon)
+
 
         adapter = MerchantCatalogAdapter(emptyList()) { catalog ->
             val intent = Intent(this, DetailedCatalogItemActivity::class.java)
@@ -127,4 +137,162 @@ class AllCatalogsMerchantActivity : AppCompatActivity() {
         val dialog = builder.create()
         dialog.show()
     }
+
+    fun onDeleteSearchIconMerchantClick(view: View) {}
+    fun onSearchCatalogIconMerchantClick(view: View) {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_search_catalogs_merchant, null)
+
+        val etName = dialogView.findViewById<EditText>(R.id.etName)
+        val spinnerArticles = dialogView.findViewById<Spinner>(R.id.etArticle)
+        val progressBarDialog1 = dialogView.findViewById<ProgressBar>(R.id.progressBarDialog1)
+        val spinnerServices = dialogView.findViewById<Spinner>(R.id.etService)
+        val progressBarDialog2 = dialogView.findViewById<ProgressBar>(R.id.progressBarDialog2)
+
+
+        // Initialization values of elements
+        etName.setText("")
+
+        fetchArticlesForDialog(spinnerArticles, progressBarDialog1)
+        fetchServicesForSpinner(spinnerServices, progressBarDialog2)
+
+        val builder = AlertDialog.Builder(this)
+            .setTitle("Search catalogs")
+            .setView(dialogView)
+            .setPositiveButton("Search") { dialog, _ ->
+
+                // Implement the search logic here
+                val name = etName.text.toString()
+                val articleSpinner = spinnerArticles.selectedItem.toString()
+                val serviceSpinner = spinnerServices.selectedItem.toString()
+
+                Log.d("Input name: ", name)
+                Log.d("Selected article - spinner: ", articleSpinner)
+                Log.d("Selected service - spinner:: ", serviceSpinner)
+
+                // Pass the dialog view to the function
+                performSearchAndUpdateRecyclerView(
+                    name,
+                    articleSpinner,
+                    serviceSpinner,
+                    progressBarDialog2
+                )
+                removeSearch.visibility = View.VISIBLE
+                dialog.dismiss()
+            }
+            .setNegativeButton("Cancel") { dialog, _ ->
+                dialog.dismiss()
+            }
+        val alertDialog = builder.create()
+        alertDialog.show()
+    }
+
+    private fun performSearchAndUpdateRecyclerView(
+        name: String,
+        articleSpinner: String,
+        serviceSpinner: String,
+        progressBarDialog: Any
+    ) {
+
+    }
+
+    private fun fetchServicesForSpinner(spinnerServices: Spinner, progressBarDialog: ProgressBar) {
+        progressBarDialog.visibility = View.VISIBLE
+
+        val retrofit = RetrofitClient.getInstance(8081)
+        val service = retrofit.create(ServiceProducts::class.java)
+        val call = service.getServicesForMerchant(loggedInUser.token, loggedInUser.userId)
+
+        call.enqueue(object : Callback<List<Service>> {
+            override fun onResponse(call: Call<List<Service>>, response: Response<List<Service>>) {
+                try {
+                    progressBarDialog.visibility = View.GONE
+
+                    if (response.isSuccessful) {
+                        val services = response.body() ?: emptyList()
+                        Log.d("AllCatalogsActivity", "Services fetched successfully: $services")
+                        // Add empty string at the begging of the list
+
+                        val serviceList = mutableListOf<String>("Services")
+                        serviceList.addAll(services.map { "${it.serviceName}" })
+
+                        val arrayAdapter = ArrayAdapter(
+                            this@AllCatalogsMerchantActivity,
+                            android.R.layout.simple_spinner_item,
+                            serviceList.toTypedArray()
+                        )
+                        arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+                        spinnerServices.adapter = arrayAdapter
+
+                    } else {
+                        showErrorDialog()
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    showErrorDialog()
+                }
+            }
+
+            override fun onFailure(call: Call<List<Service>>, t: Throwable) {
+                try {
+                    progressBarDialog.visibility = View.GONE
+                    showErrorDialog()
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    showErrorDialog()
+                }
+            }
+        })
+    }
+
+    private fun fetchArticlesForDialog(spinnerArticles: Spinner, progressBarDialog: ProgressBar) {
+        progressBarDialog.visibility = View.VISIBLE
+
+        val retrofit = RetrofitClient.getInstance(8081)
+        val service = retrofit.create(ServiceProducts::class.java)
+        val call = service.getArticlesForMerchant(loggedInUser.token, loggedInUser.userId)
+
+        call.enqueue(object : Callback<List<Article>> {
+            override fun onResponse(call: Call<List<Article>>, response: Response<List<Article>>) {
+                try {
+                    progressBarDialog.visibility = View.GONE
+
+                    if (response.isSuccessful) {
+                        val articles = response.body() ?: emptyList()
+                        Log.d("AllCatalogsActivity", "Articles fetched successfully: $articles")
+                        // Add empty string at the begging of the list
+
+                        val articleList = mutableListOf<String>("Articles")
+                        articleList.addAll(articles.map { "${it.name}" })
+
+                        val arrayAdapter = ArrayAdapter(
+                            this@AllCatalogsMerchantActivity,
+                            android.R.layout.simple_spinner_item,
+                            articleList.toTypedArray()
+                        )
+                        arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+                        spinnerArticles.adapter = arrayAdapter
+
+                    } else {
+                        showErrorDialog()
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    showErrorDialog()
+                }
+            }
+
+            override fun onFailure(call: Call<List<Article>>, t: Throwable) {
+                try {
+                    progressBarDialog.visibility = View.GONE
+                    Log.d("Failed - articles: ", call.toString() )
+                    showErrorDialog()
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    showErrorDialog()
+                }
+            }
+        })
+    }
+
+
 }

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsMerchantActivity.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsMerchantActivity.kt
@@ -9,6 +9,7 @@ import android.widget.EditText
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.Spinner
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -362,6 +363,7 @@ class AllCatalogsMerchantActivity : AppCompatActivity() {
         progressBarDialog.visibility = View.VISIBLE
         progressBar.visibility = View.VISIBLE
 
+        var merchantId: String = ""
         var serviceId: String = ""
         var articleId: String = ""
 
@@ -390,7 +392,11 @@ class AllCatalogsMerchantActivity : AppCompatActivity() {
                     if (serviceId.isNotEmpty()) put("service", serviceId)
                     if (articleId.isNotEmpty()) put("article", articleId)
                 }
+
+                searchParams["user"] = loggedInUser.userId
+
                 Log.d( "Name: ", name)
+                Log.d( "merchantId: ", merchantId)
                 Log.d( "serviceId: ", serviceId)
                 Log.d( "articleId: ", articleId)
 
@@ -404,10 +410,11 @@ class AllCatalogsMerchantActivity : AppCompatActivity() {
                         progressBar.visibility = View.GONE
                         if (response.isSuccessful) {
                             Log.d("response onResponse AllCatalogs:", response.body().toString())
-
                             val catalogs = response.body() ?: emptyList()
+
                             Log.d("AllCatalogsMerchantActivity", "Search results: $catalogs")
                             catalogMerchantAdapter.updateData(catalogs)
+
                         } else {
                             showErrorDialog()
                         }

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsMerchantActivity.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/AllCatalogsMerchantActivity.kt
@@ -135,9 +135,6 @@ class AllCatalogsMerchantActivity : AppCompatActivity() {
         dialog.show()
     }
 
-    fun onDeleteSearchIconMerchantClick(view: View) {
-
-    }
     fun onSearchCatalogIconMerchantClick(view: View) {
         val dialogView = layoutInflater.inflate(R.layout.dialog_search_catalogs_merchant, null)
 
@@ -430,5 +427,9 @@ class AllCatalogsMerchantActivity : AppCompatActivity() {
         }
     }
 
+    fun onDeleteSearchIconMerchantClick(view: View) {
+        fetchUserCatalogs(loggedInUser.userId)
+        removeSearch.visibility=View.GONE
+    }
 
 }

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/DetailedCatalogItemActivity.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/DetailedCatalogItemActivity.kt
@@ -91,10 +91,20 @@ class DetailedCatalogItemActivity : AppCompatActivity() {
 
         val imgBack: ImageView = findViewById(R.id.back_button)
         imgBack.setOnClickListener {
-            val intent= Intent(this, AllCatalogsActivity::class.java)
-            intent.putExtra("loggedInUser", loggedInUser)
-            intent.putExtra("username", userUsername)
-            onBackPressed()
+            var updatedCatalog = intent.getStringExtra("updatedCatalog") ?: ""
+            if(updatedCatalog!=""){
+                val intent= Intent(this, AllCatalogsActivity::class.java)
+                intent.putExtra("loggedInUser", loggedInUser)
+                intent.putExtra("username", userUsername)
+                startActivity(intent)
+            }
+            else{
+                val intent= Intent(this, AllCatalogsActivity::class.java)
+                intent.putExtra("loggedInUser", loggedInUser)
+                intent.putExtra("username", userUsername)
+                onBackPressed()
+            }
+
         }
 
         fetchCatalogDetails()
@@ -104,7 +114,7 @@ class DetailedCatalogItemActivity : AppCompatActivity() {
             intent.putExtra("loggedInUser", loggedInUser)
             intent.putExtra("selectedCatalog", catalog)
             intent.putExtra("username", userUsername)
-            onBackPressed()
+            startActivity(intent)
         }
     }
 

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/DetailedCatalogItemActivity.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/DetailedCatalogItemActivity.kt
@@ -94,7 +94,7 @@ class DetailedCatalogItemActivity : AppCompatActivity() {
             val intent= Intent(this, AllCatalogsActivity::class.java)
             intent.putExtra("loggedInUser", loggedInUser)
             intent.putExtra("username", userUsername)
-            startActivity(intent)
+            onBackPressed()
         }
 
         fetchCatalogDetails()
@@ -104,7 +104,7 @@ class DetailedCatalogItemActivity : AppCompatActivity() {
             intent.putExtra("loggedInUser", loggedInUser)
             intent.putExtra("selectedCatalog", catalog)
             intent.putExtra("username", userUsername)
-            startActivity(intent)
+            onBackPressed()
         }
     }
 

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/DetailedCatalogItemActivity.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/DetailedCatalogItemActivity.kt
@@ -99,23 +99,39 @@ class DetailedCatalogItemActivity : AppCompatActivity() {
                 startActivity(intent)
             }
             else{
-                val intent= Intent(this, AllCatalogsActivity::class.java)
-                intent.putExtra("loggedInUser", loggedInUser)
-                intent.putExtra("username", userUsername)
-                onBackPressed()
+                if(loggedInUser.role=="merchant"){
+                    val intent= Intent(this, AllCatalogsMerchantActivity::class.java)
+                    intent.putExtra("loggedInUser", loggedInUser)
+                    intent.putExtra("username", userUsername)
+                    onBackPressed()
+                }else{
+                    val intent= Intent(this, AllCatalogsActivity::class.java)
+                    intent.putExtra("loggedInUser", loggedInUser)
+                    intent.putExtra("username", userUsername)
+                    onBackPressed()
+                }
+
             }
 
         }
 
         fetchCatalogDetails()
 
-        btn_edit.setOnClickListener{
-            val intent = Intent(this, SelectArticlesActivity::class.java)
-            intent.putExtra("loggedInUser", loggedInUser)
-            intent.putExtra("selectedCatalog", catalog)
-            intent.putExtra("username", userUsername)
-            startActivity(intent)
+        if(loggedInUser.role=="merchant"){
+            btn_edit.visibility=View.GONE
+            btnRefresh.visibility=View.GONE
+        }else{
+            btn_edit.visibility=View.VISIBLE
+            btn_edit.setOnClickListener{
+                val intent = Intent(this, SelectArticlesActivity::class.java)
+                intent.putExtra("loggedInUser", loggedInUser)
+                intent.putExtra("selectedCatalog", catalog)
+                intent.putExtra("username", userUsername)
+                startActivity(intent)
+            }
         }
+
+
     }
 
     private fun initializeRecyclerView(recyclerView: RecyclerView) {

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/UpdateCatalogActivity.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/activity_catalogItemManagement/UpdateCatalogActivity.kt
@@ -150,7 +150,7 @@ class UpdateCatalogActivity : AppCompatActivity() {
             intent.putExtra("catalogId", currentCatalog?.id)
             intent.putExtra("loggedInUser", loggedInUser)
             intent.putExtra("username", userUsername)
-            intent.putExtra("updatedCatalog", currentCatalog)
+            intent.putExtra("updatedCatalog", currentCatalog?.id.toString())
             startActivity(intent)
         }
     }

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/model_catalogItemManagement/CatalogAdapter.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/model_catalogItemManagement/CatalogAdapter.kt
@@ -1,15 +1,18 @@
 package hr.foi.techtitans.ttpay.catalogItemManagement.model_catalogItemManagement
 
 import android.content.Context
+import android.content.Intent
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.Switch
 import android.widget.TextView
 import android.widget.Toast
 import androidx.recyclerview.widget.RecyclerView
 import hr.foi.techtitans.ttpay.R
+import hr.foi.techtitans.ttpay.catalogItemManagement.activity_catalogItemManagement.DetailedCatalogItemActivity
 import hr.foi.techtitans.ttpay.catalogItemManagement.network_catalogItemManagement.ServiceCatalogItemManagement
 import hr.foi.techtitans.ttpay.core.LoggedInUser
 import hr.foi.techtitans.ttpay.network.RetrofitClient
@@ -28,6 +31,7 @@ class CatalogAdapter(
 
     class CatalogViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val txtViewCatalogName: TextView = itemView.findViewById(R.id.textViewCatalogName)
+        val imgViewEye: ImageView = itemView.findViewById(R.id.imgView_eye_itemCatalog)
         val switchEnableDisable: Switch = itemView.findViewById(R.id.switchEnableDisable)
     }
 
@@ -49,8 +53,13 @@ class CatalogAdapter(
             updateCatalogStatus(catalog.id, catalog.name, isEnabled, holder)
         }
 
-        holder.itemView.setOnClickListener {
-            onItemClick(catalog)
+        holder.imgViewEye.setOnClickListener {
+            val intent = Intent(holder.itemView.context, DetailedCatalogItemActivity::class.java)
+            intent.putExtra("loggedInUser", loggedInUser)
+            intent.putExtra("catalogId", catalog.id)
+            intent.putExtra("selectedCatalog", catalog)
+            intent.putExtra("username", loggedInUser.username)
+            holder.itemView.context.startActivity(intent)
         }
     }
 

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/model_catalogItemManagement/CatalogAdapter.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/model_catalogItemManagement/CatalogAdapter.kt
@@ -58,7 +58,9 @@ class CatalogAdapter(
             intent.putExtra("loggedInUser", loggedInUser)
             intent.putExtra("catalogId", catalog.id)
             intent.putExtra("selectedCatalog", catalog)
+            val updatedCatalog:String =""
             intent.putExtra("username", loggedInUser.username)
+            intent.putExtra("updatedCatalog", updatedCatalog)
             holder.itemView.context.startActivity(intent)
         }
     }

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/model_catalogItemManagement/MerchantCatalogAdapter.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/model_catalogItemManagement/MerchantCatalogAdapter.kt
@@ -1,22 +1,27 @@
 package hr.foi.techtitans.ttpay.catalogItemManagement.model_catalogItemManagement
 
+import android.content.Intent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import hr.foi.techtitans.ttpay.R
+import hr.foi.techtitans.ttpay.catalogItemManagement.activity_catalogItemManagement.DetailedCatalogItemActivity
 import hr.foi.techtitans.ttpay.core.LoggedInUser
 
 
 class MerchantCatalogAdapter (
     private var catalogs: List<Catalog>,
-    private val onItemClick: (Catalog) -> Unit
+    private val loggedInUser: LoggedInUser
 ) :
     RecyclerView.Adapter<MerchantCatalogAdapter.CatalogViewHolder>() {
 
     class CatalogViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val txtViewCatalogName: TextView = itemView.findViewById(R.id.textViewCatalogName)
+        val imgViewEye: ImageView = itemView.findViewById(R.id.imgView_eye_itemCatalogMerchant)
+
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CatalogViewHolder {
@@ -29,9 +34,17 @@ class MerchantCatalogAdapter (
         val catalog = catalogs[position]
         holder.txtViewCatalogName.text = catalog.name
 
-        holder.itemView.setOnClickListener {
-            onItemClick(catalog)
+        holder.imgViewEye.setOnClickListener {
+            val intent = Intent(holder.itemView.context, DetailedCatalogItemActivity::class.java)
+            intent.putExtra("loggedInUser", loggedInUser)
+            intent.putExtra("catalogId", catalog.id)
+            intent.putExtra("selectedCatalog", catalog)
+            val updatedCatalog:String =""
+            intent.putExtra("username", loggedInUser.username)
+            intent.putExtra("updatedCatalog", updatedCatalog)
+            holder.itemView.context.startActivity(intent)
         }
+
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/network_catalogItemManagement/ServiceCatalogItemManagement.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/catalogItemManagement/network_catalogItemManagement/ServiceCatalogItemManagement.kt
@@ -3,6 +3,7 @@ package hr.foi.techtitans.ttpay.catalogItemManagement.network_catalogItemManagem
 import hr.foi.techtitans.ttpay.catalogItemManagement.createCatalog.model_createCatalog.NewCatalog
 import hr.foi.techtitans.ttpay.catalogItemManagement.createCatalog.model_createCatalog.UpdateCatalog
 import hr.foi.techtitans.ttpay.catalogItemManagement.model_catalogItemManagement.Catalog
+import hr.foi.techtitans.ttpay.transactions.model_transactions.Transaction
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.http.Body
@@ -54,4 +55,7 @@ interface ServiceCatalogItemManagement {
         @Path("catalogId") catalogId: String,
         @Body updateCatalogData:UpdateCatalog
     ):Call<ResponseBody>
+
+    @POST("/api/v1/catalogs/search")
+    fun searchCatalogs(@Body searchParams: Map<String, String>): Call<List<Catalog>>
 }

--- a/app/src/main/java/hr/foi/techtitans/ttpay/products/network_products/ServiceProducts.kt
+++ b/app/src/main/java/hr/foi/techtitans/ttpay/products/network_products/ServiceProducts.kt
@@ -91,5 +91,15 @@ interface ServiceProducts {
         @Path("userId") userId: String?
     ): Call<List<Service>>
 
+    @GET("/api/v1/services/user/{userId}")
+    fun getServicesForMerchant(
+        @Header("Authorization") token: String,
+        @Path("userId") userId: String?
+    ): Call<List<Service>>
 
+    @GET("/api/v1/articles/user/{userId}")
+    fun getArticlesForMerchant(
+        @Header("Authorization") token: String,
+        @Path("userId") userId: String?
+    ): Call<List<Article>>
 }

--- a/app/src/main/res/layout/activity_all_catalogs.xml
+++ b/app/src/main/res/layout/activity_all_catalogs.xml
@@ -52,7 +52,7 @@
             android:layout_height="50dp"
             android:layout_alignParentEnd="true"
             android:layout_marginEnd="60dp"
-            android:onClick="onSearchTransactionIconClick"
+            android:onClick="onSearchCatalogIconClick"
             android:src="@drawable/baseline_search" />
 
         <ImageView

--- a/app/src/main/res/layout/activity_all_catalogs.xml
+++ b/app/src/main/res/layout/activity_all_catalogs.xml
@@ -46,6 +46,24 @@
             android:layout_marginEnd="10dp"
             android:onClick="onPlusCatalogIconClick"
             android:src="@drawable/add_circle" />
+        <ImageView
+            android:id="@+id/img_search_icon"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_alignParentEnd="true"
+            android:layout_marginEnd="60dp"
+            android:onClick="onSearchTransactionIconClick"
+            android:src="@drawable/baseline_search" />
+
+        <ImageView
+            android:id="@+id/img_delete_search_icon"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_alignParentEnd="true"
+            android:layout_marginEnd="110dp"
+            android:onClick="onDeleteSearchIconClick"
+            android:visibility="gone"
+            android:src="@drawable/baseline_search_off" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/activity_all_catalogs_merchant.xml
+++ b/app/src/main/res/layout/activity_all_catalogs_merchant.xml
@@ -29,12 +29,40 @@
         android:textSize="24sp"
         android:textStyle="bold" />
 
+    <RelativeLayout
+        android:id="@+id/rl_plus_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/tv_all_catalogs_merchant_title"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="20dp">
+        <ImageView
+            android:id="@+id/img_search_icon"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_alignParentEnd="true"
+            android:layout_marginEnd="60dp"
+            android:onClick="onSearchCatalogIconClick"
+            android:src="@drawable/baseline_search" />
+
+        <ImageView
+            android:id="@+id/img_delete_search_icon"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_alignParentEnd="true"
+            android:layout_marginEnd="110dp"
+            android:onClick="onDeleteSearchIconClick"
+            android:visibility="gone"
+            android:src="@drawable/baseline_search_off" />
+
+</RelativeLayout>
+
     <!-- Message above RecyclerView -->
     <TextView
         android:id="@+id/tv_catalog_select"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/tv_all_catalogs_merchant_title"
+        android:layout_below="@id/rl_plus_icon"
         android:layout_centerHorizontal="true"
         android:layout_marginTop="16dp"
         android:text="Select the catalog you want to see"

--- a/app/src/main/res/layout/activity_all_catalogs_merchant.xml
+++ b/app/src/main/res/layout/activity_all_catalogs_merchant.xml
@@ -42,7 +42,7 @@
             android:layout_height="50dp"
             android:layout_alignParentEnd="true"
             android:layout_marginEnd="60dp"
-            android:onClick="onSearchCatalogIconClick"
+            android:onClick="onSearchCatalogIconMerchantClick"
             android:src="@drawable/baseline_search" />
 
         <ImageView
@@ -51,7 +51,7 @@
             android:layout_height="50dp"
             android:layout_alignParentEnd="true"
             android:layout_marginEnd="110dp"
-            android:onClick="onDeleteSearchIconClick"
+            android:onClick="onDeleteSearchIconMerchantClick"
             android:visibility="gone"
             android:src="@drawable/baseline_search_off" />
 

--- a/app/src/main/res/layout/dialog_search_catalogs.xml
+++ b/app/src/main/res/layout/dialog_search_catalogs.xml
@@ -1,0 +1,46 @@
+ <LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <EditText
+            android:id="@+id/etName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:textSize="16sp"
+            android:hint="Description" />
+
+        <EditText
+            android:id="@+id/etArticle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:textSize="16sp"
+            android:hint="2023-12-22" />
+
+
+     <EditText
+         android:id="@+id/etService"
+         android:layout_width="match_parent"
+         android:layout_height="wrap_content"
+         android:layout_margin="8dp"
+         android:textSize="16sp"
+         android:hint="2023-12-22" />
+
+     <EditText
+         android:id="@+id/etUser"
+         android:layout_width="match_parent"
+         android:layout_height="wrap_content"
+         android:layout_margin="8dp"
+         android:textSize="16sp"
+         android:hint="2023-12-22" />
+
+        <ProgressBar
+            android:id="@+id/progressBarDialog"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:visibility="gone"/>
+    </LinearLayout>

--- a/app/src/main/res/layout/dialog_search_catalogs.xml
+++ b/app/src/main/res/layout/dialog_search_catalogs.xml
@@ -18,6 +18,12 @@
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
             android:textSize="16sp" />
+     <ProgressBar
+         android:id="@+id/progressBarDialog1"
+         android:layout_width="wrap_content"
+         android:layout_height="wrap_content"
+         android:layout_gravity="center"
+         android:visibility="gone"/>
 
 
      <Spinner
@@ -26,6 +32,12 @@
          android:layout_height="wrap_content"
          android:layout_margin="8dp"
          android:textSize="16sp" />
+     <ProgressBar
+         android:id="@+id/progressBarDialog2"
+         android:layout_width="wrap_content"
+         android:layout_height="wrap_content"
+         android:layout_gravity="center"
+         android:visibility="gone"/>
 
      <Spinner
          android:id="@+id/etUser"
@@ -35,7 +47,7 @@
          android:textSize="16sp" />
 
         <ProgressBar
-            android:id="@+id/progressBarDialog"
+            android:id="@+id/progressBarDialog3"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"

--- a/app/src/main/res/layout/dialog_search_catalogs.xml
+++ b/app/src/main/res/layout/dialog_search_catalogs.xml
@@ -10,7 +10,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
             android:textSize="16sp"
-            android:hint="Description" />
+            android:hint="Name" />
 
         <Spinner
             android:id="@+id/etArticle"

--- a/app/src/main/res/layout/dialog_search_catalogs.xml
+++ b/app/src/main/res/layout/dialog_search_catalogs.xml
@@ -12,30 +12,27 @@
             android:textSize="16sp"
             android:hint="Description" />
 
-        <EditText
+        <Spinner
             android:id="@+id/etArticle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
-            android:textSize="16sp"
-            android:hint="2023-12-22" />
+            android:textSize="16sp" />
 
 
-     <EditText
+     <Spinner
          android:id="@+id/etService"
          android:layout_width="match_parent"
          android:layout_height="wrap_content"
          android:layout_margin="8dp"
-         android:textSize="16sp"
-         android:hint="2023-12-22" />
+         android:textSize="16sp" />
 
-     <EditText
+     <Spinner
          android:id="@+id/etUser"
          android:layout_width="match_parent"
          android:layout_height="wrap_content"
          android:layout_margin="8dp"
-         android:textSize="16sp"
-         android:hint="2023-12-22" />
+         android:textSize="16sp" />
 
         <ProgressBar
             android:id="@+id/progressBarDialog"

--- a/app/src/main/res/layout/dialog_search_catalogs_merchant.xml
+++ b/app/src/main/res/layout/dialog_search_catalogs_merchant.xml
@@ -1,0 +1,45 @@
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/etName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:textSize="16sp"
+        android:hint="Name" />
+
+    <Spinner
+        android:id="@+id/etArticle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:textSize="16sp" />
+
+    <ProgressBar
+        android:id="@+id/progressBarDialog1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone"/>
+
+
+    <Spinner
+        android:id="@+id/etService"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:textSize="16sp" />
+
+    <ProgressBar
+        android:id="@+id/progressBarDialog2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone"/>
+
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_catalog.xml
+++ b/app/src/main/res/layout/item_catalog.xml
@@ -2,7 +2,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="80dp"
     android:orientation="horizontal"
     android:gravity="center_vertical"
     android:padding="16dp">
@@ -10,22 +10,32 @@
     <!-- TextView for catalog name -->
     <TextView
         android:id="@+id/textViewCatalogName"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_width="283dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
         android:layout_weight="1"
         android:background="@drawable/red_border_item"
-        android:gravity="center"
-        android:padding="16dp"
+        android:padding="12dp"
         android:text="Catalog name"
-        android:textSize="16sp"
-        android:layout_gravity="center"/>
+        android:textAlignment="center"
+        android:textSize="15sp" />
+
+    <!-- ImageView with eye icon -->
+    <ImageView
+        android:id="@+id/imgView_eye_itemCatalog"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:src="@drawable/ic_eye"
+        android:layout_gravity="end"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        />
 
     <!-- Switch for enable/disable -->
     <Switch
         android:id="@+id/switchEnableDisable"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text=""
-        android:layout_gravity="center"/>
-
+        android:gravity="end"
+        android:text=""/>
 </LinearLayout>

--- a/app/src/main/res/layout/item_merchant_catalog.xml
+++ b/app/src/main/res/layout/item_merchant_catalog.xml
@@ -1,12 +1,32 @@
-<!-- res/layout/item_merchant_catalog.xml -->
-<TextView
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/textViewCatalogName"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@drawable/red_border_item"
-    android:gravity="center"
-    android:padding="16dp"
-    android:text="Catalog name"
-    android:layout_marginBottom="5dp"
-    android:textSize="16sp"/>
+    android:layout_height="80dp"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:padding="16dp">
+
+    <!-- TextView for catalog name -->
+    <TextView
+        android:id="@+id/textViewCatalogName"
+        android:layout_width="283dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:layout_weight="1"
+        android:background="@drawable/red_border_item"
+        android:padding="12dp"
+        android:text="Catalog name"
+        android:textAlignment="center"
+        android:textSize="15sp" />
+
+    <!-- ImageView with eye icon -->
+    <ImageView
+        android:id="@+id/imgView_eye_itemCatalogMerchant"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:src="@drawable/ic_eye"
+        android:layout_gravity="end"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        />
+</LinearLayout>


### PR DESCRIPTION
Within this branch is implemented search for catalogs in both roles, merchant and admin. Difference is that merchant only can see his own catalogs and not catalogs of others. Also merchant can't search by users, only by name, article and service. On the other hand admin can search and by name, user, article, catalog. 

Key modifications extend to the CatalogAdapter, now equipped with a function facilitating the eye icon's role in revealing catalog details. Search functionality for catalogs in an admin role has been successfully implemented, addressing the intended functionality. The layout tailored for merchant views of all catalogs (TT-117) has undergone refinement. Specifically, a dedicated dialog empowers merchants to search for catalog names, articles, and services, and this dialog now accurately displays pertinent data.

The back button functionality has been updated to prevent unintended switches to the AllCatalogs activity. An eye icon has been seamlessly incorporated for the detailed view of catalogs, accompanied by an efficient method to support this feature. Importantly, a method enabling the search for catalogs pertaining to a specific merchant, identified by their merchant ID (TT-117), has been implemented. The capacity to remove search filters and revert to displaying all catalogs for a merchant is now a seamless part of the user experience.

Testing is essential to ensure the reliability and functionality of the recent catalog search feature implementations, encompassing both merchant and admin roles, along with various user interface updates.